### PR TITLE
Update ServerBuilder.WithAddress overloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The default address and port can easily be changed using `builder.WithAddress()`
 ```csharp
 var builder = new ServerBuilder();
 
-builder.WithAddress(new IPAddress([192, 168, 1, 1]));
+builder.WithAddress("192.168.1.1");
 builder.WithPort(8000);
 
 var server = builder.Build();

--- a/src/Server/LiteHttp/src/LiteHttp/ServerBuilder.cs
+++ b/src/Server/LiteHttp/src/LiteHttp/ServerBuilder.cs
@@ -69,6 +69,9 @@ public class ServerBuilder
     /// <returns>The current <see cref="ServerBuilder"/> instance with the updated address.</returns>
     public ServerBuilder WithAddress(IPAddress address)
     {
+        if (address.AddressFamily != AddressFamily.InterNetwork) 
+            throw new NotSupportedException("IPv4 only supported");
+
         _address = address;
 
         return this;
@@ -83,34 +86,15 @@ public class ServerBuilder
     /// <param name="address">The host name or IPv4 address to use for the server. An <see cref="ArgumentNullException"/> is thrown if null.</param>
     /// <returns>The current <see cref="ServerBuilder"/> instance with the updated address.</returns>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="address"/> is null.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">The <paramref name="address"/> is invalid IPv4 address.</exception>
-    /// <exception cref="ArgumentException">The <paramref name="address"/> is invalid IPv4 address.</exception>
+    /// <exception cref="FormatException">The <paramref name="address"/> is invalid IPv4 address.</exception>
     public ServerBuilder WithAddress(string address)
     {
-        ArgumentNullException.ThrowIfNullOrWhiteSpace(address);
-        
-        if (address.Any(c => !char.IsDigit(c) || c.Equals('.')))
-            throw new ArgumentException("Got invalid IP address");
+        var parsed = IPAddress.Parse(address);
 
-        var parts = address.Split('.');
-        
-        ArgumentOutOfRangeException.ThrowIfNotEqual(parts.Length, 4, "Got invalid address");
-        
-        var byteParts = new byte[4];
-
-        for (var i = 0; i < parts.Length; i++)
-        {
-            var part = parts[i];
-
-            ArgumentOutOfRangeException.ThrowIfGreaterThan(part.Length, 3);
-
-            if (!byte.TryParse(part, out var bytePart))
-                throw new ArgumentException("Got invalid IP Adress");
-
-            byteParts[i] = bytePart;
-        }
-
-        _address = new IPAddress(byteParts);
+        if (parsed.AddressFamily != AddressFamily.InterNetwork) 
+            throw new NotSupportedException("IPv4 only supported");
+            
+        _address = parsed; 
 
         return this;
     }

--- a/src/Server/LiteHttp/src/LiteHttp/ServerBuilder.cs
+++ b/src/Server/LiteHttp/src/LiteHttp/ServerBuilder.cs
@@ -75,25 +75,42 @@ public class ServerBuilder
     }
 
     /// <summary>
-    /// Sets the server's network address using the specified host name or IP address.
+    /// Sets the server's network address using provided address.
     /// </summary>
     /// <remarks>
-    /// Only IPv4 addresses are considered. If the host cannot be resolved or contains no IPv4 entries,
-    /// an exception will be thrown.
-    /// <para>
-    /// If multiple addresses are resolved for the specified host, the first IPv4 address is used.
-    /// </para>
+    /// Only IPv4 addresses are considered.
     /// </remarks>
     /// <param name="address">The host name or IPv4 address to use for the server. An <see cref="ArgumentNullException"/> is thrown if null.</param>
     /// <returns>The current <see cref="ServerBuilder"/> instance with the updated address.</returns>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="address"/> is null</exception>
-    /// <exception cref="ArgumentOutOfRangeException">The <paramref name="address"/> length is greater than 255 characters.</exception>
-    /// <exception cref="SocketException">An error is encountered when resolving.<paramref name="address"/></exception>
-    /// <exception cref="ArgumentException"><paramref name="address"/> is invalid IP address.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="address"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">The <paramref name="address"/> is invalid IPv4 address.</exception>
+    /// <exception cref="ArgumentException">The <paramref name="address"/> is invalid IPv4 address.</exception>
     public ServerBuilder WithAddress(string address)
     {
-        _address = Dns.GetHostAddresses(address)
-            .First(a => a.AddressFamily == AddressFamily.InterNetwork);
+        ArgumentNullException.ThrowIfNullOrWhiteSpace(address);
+        
+        if (address.Any(c => !char.IsDigit(c) || c.Equals('.')))
+            throw new ArgumentException("Got invalid IP address");
+
+        var parts = address.Split('.');
+        
+        ArgumentOutOfRangeException.ThrowIfNotEqual(parts.Length, 4, "Got invalid address");
+        
+        var byteParts = new byte[4];
+
+        for (var i = 0; i < parts.Length; i++)
+        {
+            var part = parts[i];
+
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(part.Length, 3);
+
+            if (!byte.TryParse(part, out var bytePart))
+                throw new ArgumentException("Got invalid IP Adress");
+
+            byteParts[i] = bytePart;
+        }
+
+        _address = new IPAddress(byteParts);
 
         return this;
     }

--- a/src/Server/LiteHttp/tests/ServerBuilderTests.cs
+++ b/src/Server/LiteHttp/tests/ServerBuilderTests.cs
@@ -1,4 +1,6 @@
-﻿using LiteHttp;
+﻿using System.Net.NetworkInformation;
+
+using LiteHttp;
 
 namespace UnitTests.LiteHttp.Server.Public;
 
@@ -23,4 +25,77 @@ public class ServerBuilderTests
         // Act & Assert
         action.Should().Throw<ArgumentException>();
     }
+
+
+    [Fact]
+    public void WithAddress_ValidIPv6Address_ShouldThrow_NotSupportedException()
+    {
+        // Arrange
+        var address = IPAddress.IPv6Loopback;
+        var builder = new ServerBuilder();
+
+        var action = () => builder.WithAddress(address);
+
+        // Act & Assert
+        action.Should().Throw<NotSupportedException>();
+    }
+
+    [Fact]
+    public void WithAddress_IPv4AddressWithChars_ShouldThrow_FormatException()
+    {
+        // Arrange
+        var address = "123.123.123.asd";
+        var builder = new ServerBuilder();
+
+        var action = () => builder.WithAddress(address);
+
+        // Act & Assert
+        action.Should().Throw<FormatException>();
+    }
+
+    
+    [Fact]
+    public void WithAddress_TooLongIPv4Address_ShouldThrow_FormatException()
+    {
+        // Arrange
+        var address = "123.123.123.1234";
+        var builder = new ServerBuilder();
+
+        var action = () => builder.WithAddress(address);
+
+        // Act & Assert
+        action.Should().Throw<FormatException>();
+    }
+
+        
+    [Fact]
+    public void WithAddress_NullParameter_ShouldThrow_ArgumentNullException()
+    {
+        // Arrange
+        string? address = null;
+        var builder = new ServerBuilder();
+
+        var action = () => builder.WithAddress(address!);
+
+        // Act & Assert
+        action.Should().Throw<ArgumentNullException>();
+    }
+    
+    
+    [Fact]
+    public void WithAddress_IPv4Address_ShouldSet()
+    {
+        // Arrange
+        var address = IPAddress.Loopback;
+        var builder = new ServerBuilder();
+        var field = GetIpAddressField(builder);
+
+        var action = () => builder.WithAddress(address);
+
+        // Act & Assert
+        action.Should().NotThrow();
+    }
+
+    private static System.Reflection.FieldInfo? GetIpAddressField(ServerBuilder builder) =>
+        builder.GetType().GetField("_address");
 }


### PR DESCRIPTION
## Summary
Public api update to minimize missunderstands of the public api. 

## Changes
- Now throws if address is not IPv4
- Old domain resolvment using Dns server replaced with address parsing
- README.md and documentation updated according api changes
- Introduce tests for updated api